### PR TITLE
ci: enable npm trusted publishers

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -170,12 +170,10 @@ jobs:
         working-directory: volumecontrol-napi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_ID: ${{ steps.gh_release.outputs.gh_release_id }}
           VERSION: ${{ steps.gh_release.outputs.version }}
         run: |
           npm config set provenance true
-          npm set "//registry.npmjs.org/:_authToken" $NPM_TOKEN
 
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             npm publish --access public

--- a/volumecontrol-napi/package.json
+++ b/volumecontrol-napi/package.json
@@ -13,8 +13,7 @@
   },
   "files": [
     "index.js",
-    "index.d.ts",
-    "*.node"
+    "index.d.ts"
   ],
   "scripts": {
     "build": "napi build --platform --release",


### PR DESCRIPTION
Removed NPM_TOKEN from environment variables in release workflow.